### PR TITLE
fix: GCP storage adapter signed URL generation with service account c…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,10 @@ lerna-debug.log*
 .env
 /ormconfig.json
 .codegpt
+
+# GCP Service Account Keys (NEVER commit these!)
+.secrets/
+*.json.key
+*service-account*.json
+keystone-sa-key.json
+gcp-*.json

--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ Each service can scale independently, while Core ensures consistent authenticati
 
 ## 🛠️ Setup
 
+### Quick Start
+
 ```bash
 git clone https://github.com/YOUR_TEAM/keystone-core-api
 cd keystone-core-api
@@ -103,6 +105,55 @@ cp .env.sample .env
 npm install
 npm run start:dev
 ```
+
+### GCP Credentials Setup (Required for Document Processing)
+
+The document download endpoint requires GCP service account credentials for generating signed URLs. Follow these steps:
+
+#### Option 1: Automated Setup Script
+
+```bash
+# Run the setup script (creates service account, grants permissions, generates key)
+./SETUP_SERVICE_ACCOUNT.sh
+
+# Add to your .env file (the script will show you the exact path)
+GOOGLE_APPLICATION_CREDENTIALS=.secrets/keystone-sa-key.json
+```
+
+#### Option 2: Manual Setup
+
+1. **Create Service Account:**
+   ```bash
+   gcloud iam service-accounts create keystone-doc-processing \
+     --display-name="Keystone Document Processing" \
+     --project=YOUR_PROJECT_ID
+   ```
+
+2. **Grant Permissions:**
+   ```bash
+   gcloud projects add-iam-policy-binding YOUR_PROJECT_ID \
+     --member="serviceAccount:keystone-doc-processing@YOUR_PROJECT_ID.iam.gserviceaccount.com" \
+     --role="roles/storage.objectAdmin"
+   ```
+
+3. **Create Key File:**
+   ```bash
+   gcloud iam service-accounts keys create .secrets/keystone-sa-key.json \
+     --iam-account=keystone-doc-processing@YOUR_PROJECT_ID.iam.gserviceaccount.com
+   ```
+
+4. **Add to .env:**
+   ```bash
+   GOOGLE_APPLICATION_CREDENTIALS=.secrets/keystone-sa-key.json
+   ```
+
+5. **Restart Application**
+
+**Security Note:** The `.secrets/` directory is excluded from git via `.gitignore`. Never commit service account keys to version control.
+
+For more details, see:
+- [`docs/gcp-authentication-setup.md`](/docs/gcp-authentication-setup.md) - Complete GCP authentication guide
+- [`VERIFY_GCP_CREDENTIALS.md`](/VERIFY_GCP_CREDENTIALS.md) - Troubleshooting guide
 
 Docker + CI setup also available.
 

--- a/SETUP_SERVICE_ACCOUNT.sh
+++ b/SETUP_SERVICE_ACCOUNT.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+# Setup script for GCP Service Account for Keystone Document Processing
+# This service account is required for generating signed URLs for document downloads
+
+set -e  # Exit on error
+
+PROJECT_ID="anythingllm-dropdev-hybrid-v1"
+SERVICE_ACCOUNT_NAME="keystone-doc-processing"
+SERVICE_ACCOUNT_EMAIL="${SERVICE_ACCOUNT_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"
+KEY_FILE_HOME="${HOME}/keystone-sa-key.json"
+KEY_FILE_PROJECT=".secrets/keystone-sa-key.json"
+
+echo "🔧 Setting up GCP Service Account for Keystone Document Processing"
+echo "Project ID: ${PROJECT_ID}"
+echo "Service Account: ${SERVICE_ACCOUNT_EMAIL}"
+echo ""
+
+# Step 1: Create service account (if it doesn't exist)
+echo "📝 Step 1: Creating service account..."
+if gcloud iam service-accounts describe "${SERVICE_ACCOUNT_EMAIL}" --project="${PROJECT_ID}" &>/dev/null; then
+  echo "✅ Service account already exists: ${SERVICE_ACCOUNT_EMAIL}"
+else
+  echo "Creating new service account..."
+  gcloud iam service-accounts create "${SERVICE_ACCOUNT_NAME}" \
+    --display-name="Keystone Document Processing" \
+    --description="Service account for document storage and OCR" \
+    --project="${PROJECT_ID}"
+  echo "✅ Service account created: ${SERVICE_ACCOUNT_EMAIL}"
+fi
+echo ""
+
+# Step 2: Grant required permissions
+echo "🔐 Step 2: Granting required permissions..."
+
+# Cloud Storage - read/write objects (required for upload/download)
+echo "Granting storage.objectAdmin role..."
+gcloud projects add-iam-policy-binding "${PROJECT_ID}" \
+  --member="serviceAccount:${SERVICE_ACCOUNT_EMAIL}" \
+  --role="roles/storage.objectAdmin" \
+  --condition=None
+
+echo "✅ Permissions granted"
+echo ""
+
+# Step 3: Create and download key
+echo "🔑 Step 3: Creating service account key..."
+if [ -f "${KEY_FILE_HOME}" ]; then
+  echo "⚠️  Key file already exists: ${KEY_FILE_HOME}"
+  read -p "Do you want to overwrite it? (y/N): " -n 1 -r
+  echo
+  if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+    echo "Skipping key creation. Using existing key file."
+  else
+    gcloud iam service-accounts keys create "${KEY_FILE_HOME}" \
+      --iam-account="${SERVICE_ACCOUNT_EMAIL}" \
+      --project="${PROJECT_ID}"
+    echo "✅ Service account key created: ${KEY_FILE_HOME}"
+  fi
+else
+  gcloud iam service-accounts keys create "${KEY_FILE_HOME}" \
+    --iam-account="${SERVICE_ACCOUNT_EMAIL}" \
+    --project="${PROJECT_ID}"
+  echo "✅ Service account key created: ${KEY_FILE_HOME}"
+fi
+echo ""
+
+# Step 4: Copy to project directory
+echo "📁 Step 4: Copying key to project directory..."
+mkdir -p .secrets
+cp "${KEY_FILE_HOME}" "${KEY_FILE_PROJECT}"
+chmod 600 "${KEY_FILE_PROJECT}"
+echo "✅ Key copied to: ${KEY_FILE_PROJECT}"
+echo ""
+
+# Step 5: Verify key file
+echo "🔍 Step 5: Verifying key file..."
+if [ -f "${KEY_FILE_PROJECT}" ]; then
+  CLIENT_EMAIL=$(cat "${KEY_FILE_PROJECT}" | grep -o '"client_email": "[^"]*"' | cut -d'"' -f4)
+  if [ -n "${CLIENT_EMAIL}" ]; then
+    echo "✅ Key file is valid"
+    echo "   Client Email: ${CLIENT_EMAIL}"
+  else
+    echo "❌ Key file is invalid (missing client_email)"
+    exit 1
+  fi
+else
+  echo "❌ Key file not found: ${KEY_FILE_PROJECT}"
+  exit 1
+fi
+echo ""
+
+# Step 6: Set environment variable instructions
+echo "📋 Step 6: Next steps"
+echo ""
+echo "The key file has been copied to the project directory:"
+echo "  - Home: ${KEY_FILE_HOME}"
+echo "  - Project: ${KEY_FILE_PROJECT}"
+echo ""
+echo "Add this to your .env file (using absolute path):"
+ABSOLUTE_PATH=$(cd "$(dirname "${KEY_FILE_PROJECT}")" && pwd)/$(basename "${KEY_FILE_PROJECT}")
+echo "GOOGLE_APPLICATION_CREDENTIALS=${ABSOLUTE_PATH}"
+echo ""
+echo "Or use relative path (if running from project root):"
+echo "GOOGLE_APPLICATION_CREDENTIALS=${KEY_FILE_PROJECT}"
+echo ""
+echo "✅ Setup complete!"
+echo ""
+echo "⚠️  IMPORTANT:"
+echo "   - Key files are in .gitignore and will NOT be committed"
+echo "   - Keep these files secure and never commit them to git"
+echo "   - Both copies are kept for convenience (home + project)"
+

--- a/src/document-processing/infrastructure/storage/gcp-storage.adapter.ts
+++ b/src/document-processing/infrastructure/storage/gcp-storage.adapter.ts
@@ -1,6 +1,11 @@
-import { Injectable, Logger } from '@nestjs/common';
+import {
+  Injectable,
+  Logger,
+  ServiceUnavailableException,
+} from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { Storage, Bucket, File } from '@google-cloud/storage';
+import * as fs from 'fs';
 import {
   StorageServicePort,
   FileMetadata,
@@ -35,9 +40,24 @@ export class GcpStorageAdapter implements StorageServicePort {
   private readonly processedPrefix: string;
 
   constructor(private readonly configService: ConfigService<AllConfigType>) {
-    // TODO: In production, use Workload Identity (GKE) or service account key
-    // GOOGLE_APPLICATION_CREDENTIALS env var should point to key file
-    this.storage = new Storage();
+    // Initialize Storage with explicit credentials if GOOGLE_APPLICATION_CREDENTIALS is set
+    // This ensures signed URLs work (requires service account with client_email)
+    const credentialsPath = process.env.GOOGLE_APPLICATION_CREDENTIALS;
+    if (credentialsPath) {
+      this.storage = new Storage({
+        keyFilename: credentialsPath,
+      });
+      this.logger.log(
+        `GCP Storage initialized with service account: ${credentialsPath}`,
+      );
+    } else {
+      // Fallback to ADC (Application Default Credentials)
+      // NOTE: ADC may not work for signed URLs - requires service account with client_email
+      this.storage = new Storage();
+      this.logger.warn(
+        'GCP Storage initialized with ADC. Signed URLs require a service account key file. Set GOOGLE_APPLICATION_CREDENTIALS for production.',
+      );
+    }
 
     const bucketName = this.configService.getOrThrow(
       'documentProcessing.gcp.storage.bucket',
@@ -57,7 +77,59 @@ export class GcpStorageAdapter implements StorageServicePort {
     );
 
     this.logger.log('GCP Storage adapter initialized');
+
+    // Validate credentials for signed URL generation
+    this.validateSignedUrlCredentials();
     // TODO: Verify bucket exists and is accessible on startup
+  }
+
+  /**
+   * Validate that credentials are configured for signed URL generation
+   * This is a best-effort check - actual validation happens at runtime
+   */
+  private validateSignedUrlCredentials(): void {
+    const credentialsPath = process.env.GOOGLE_APPLICATION_CREDENTIALS;
+    if (!credentialsPath) {
+      this.logger.warn(
+        '⚠️  GOOGLE_APPLICATION_CREDENTIALS not set. Signed URL generation will fail.',
+      );
+      this.logger.warn(
+        '   Set GOOGLE_APPLICATION_CREDENTIALS to a service account key file path.',
+      );
+      this.logger.warn(
+        '   Application Default Credentials cannot be used for signed URLs.',
+      );
+    } else {
+      // Try to verify the file exists and is readable
+      try {
+        if (!fs.existsSync(credentialsPath)) {
+          this.logger.error(
+            `❌ Service account key file not found: ${credentialsPath}`,
+          );
+        } else {
+          // Try to parse JSON to verify it's a valid service account key
+          const keyContent = fs.readFileSync(credentialsPath, 'utf8');
+          const keyJson = JSON.parse(keyContent);
+          if (!keyJson.client_email) {
+            this.logger.error(
+              `❌ Service account key file missing 'client_email' field: ${credentialsPath}`,
+            );
+            this.logger.error(
+              '   This file may be user credentials, not a service account key.',
+            );
+          } else {
+            this.logger.log(
+              `✅ Service account credentials validated: ${keyJson.client_email}`,
+            );
+          }
+        }
+      } catch (error) {
+        this.logger.warn(
+          `⚠️  Could not validate service account key file: ${credentialsPath}`,
+        );
+        this.logger.warn(`   Error: ${(error as Error).message}`);
+      }
+    }
   }
 
   async storeRaw(fileBuffer: Buffer, metadata: FileMetadata): Promise<string> {
@@ -94,6 +166,15 @@ export class GcpStorageAdapter implements StorageServicePort {
 
       return gcsUri;
     } catch (error) {
+      const authError = this.detectAuthError(error);
+      if (authError) {
+        this.logger.error(
+          `GCP authentication error for document ${metadata.documentId}: ${authError.message}`,
+        );
+        this.logger.error(authError.remediation);
+        throw new Error(authError.userMessage);
+      }
+
       this.logger.error(
         `Failed to upload raw file for document ${metadata.documentId}: ${this.sanitizeError(error)}`,
       );
@@ -128,6 +209,15 @@ export class GcpStorageAdapter implements StorageServicePort {
 
       return gcsUri;
     } catch (error) {
+      const authError = this.detectAuthError(error);
+      if (authError) {
+        this.logger.error(
+          `GCP authentication error for document ${metadata.documentId}: ${authError.message}`,
+        );
+        this.logger.error(authError.remediation);
+        throw new Error(authError.userMessage);
+      }
+
       this.logger.error(
         `Failed to store processed output for document ${metadata.documentId}: ${this.sanitizeError(error)}`,
       );
@@ -150,6 +240,15 @@ export class GcpStorageAdapter implements StorageServicePort {
       if ((error as any).code === 404) {
         this.logger.debug('File already deleted or does not exist');
         return;
+      }
+
+      const authError = this.detectAuthError(error);
+      if (authError) {
+        this.logger.error(
+          `GCP authentication error during delete: ${authError.message}`,
+        );
+        this.logger.error(authError.remediation);
+        throw new Error(authError.userMessage);
       }
 
       this.logger.error(
@@ -177,10 +276,26 @@ export class GcpStorageAdapter implements StorageServicePort {
 
       return url;
     } catch (error) {
+      const authError = this.detectAuthError(error);
+      if (authError) {
+        // Log detailed error and remediation on server side only (security: don't expose to clients)
+        this.logger.error(
+          `GCP authentication error generating signed URL: ${authError.message}`,
+        );
+        this.logger.error(authError.remediation);
+        // Return generic error to client (no internal details exposed)
+        throw new ServiceUnavailableException(
+          'Service temporarily unavailable. Please contact support if this issue persists.',
+        );
+      }
+
       this.logger.error(
         `Failed to generate signed URL: ${this.sanitizeError(error)}`,
       );
-      throw new Error('Failed to generate download URL');
+      // Return generic error to client (no internal details exposed)
+      throw new ServiceUnavailableException(
+        'Service temporarily unavailable. Please contact support if this issue persists.',
+      );
     }
   }
 
@@ -198,6 +313,120 @@ export class GcpStorageAdapter implements StorageServicePort {
     const objectKey = parts.slice(1).join('/');
 
     return { bucket, objectKey };
+  }
+
+  /**
+   * Detect authentication errors and provide remediation guidance
+   */
+  private detectAuthError(error: any): {
+    message: string;
+    userMessage: string;
+    remediation: string;
+  } | null {
+    const errorStr = JSON.stringify(error || {});
+    const errorMessage = error?.message || errorStr;
+    const errorCode = error?.code;
+    const errorSubtype = error?.error_subtype;
+
+    // Check for missing client_email (required for signed URLs)
+    if (
+      errorMessage.includes('Cannot sign data without') ||
+      errorMessage.includes('client_email') ||
+      errorMessage.includes('client_email is required')
+    ) {
+      const hasServiceAccount = !!process.env.GOOGLE_APPLICATION_CREDENTIALS;
+      const remediation = hasServiceAccount
+        ? `Service account key file is set but may be invalid or missing client_email. Verify:
+   1. GOOGLE_APPLICATION_CREDENTIALS points to a valid service account JSON key file
+   2. The JSON file contains a "client_email" field (not user credentials)
+   3. The service account has required permissions (roles/storage.objectAdmin)
+   4. Regenerate the service account key if needed:
+      gcloud iam service-accounts keys create key.json --iam-account=SERVICE_ACCOUNT@PROJECT.iam.gserviceaccount.com`
+        : `Signed URLs require a service account key file (not Application Default Credentials).
+   
+   To fix:
+   1. Create a service account (if you don't have one):
+      gcloud iam service-accounts create keystone-doc-processing \\
+        --display-name="Keystone Document Processing"
+   
+   2. Grant required permissions:
+      gcloud projects add-iam-policy-binding YOUR_PROJECT_ID \\
+        --member="serviceAccount:keystone-doc-processing@YOUR_PROJECT_ID.iam.gserviceaccount.com" \\
+        --role="roles/storage.objectAdmin"
+   
+   3. Create and download the key:
+      gcloud iam service-accounts keys create ~/keystone-sa-key.json \\
+        --iam-account=keystone-doc-processing@YOUR_PROJECT_ID.iam.gserviceaccount.com
+   
+   4. Set environment variable:
+      export GOOGLE_APPLICATION_CREDENTIALS=~/keystone-sa-key.json
+   
+   Note: Application Default Credentials (from gcloud auth application-default login) 
+   cannot be used for signed URLs - you must use a service account key file.`;
+
+      return {
+        message:
+          'GCP signed URL generation requires service account with client_email',
+        userMessage:
+          'Failed to generate download URL: Service account credentials required. Application Default Credentials cannot be used for signed URLs.',
+        remediation,
+      };
+    }
+
+    // Check for invalid_rapt (reauthentication required)
+    if (
+      errorSubtype === 'invalid_rapt' ||
+      errorMessage.includes('invalid_rapt') ||
+      (error?.error === 'invalid_grant' &&
+        errorMessage.includes('reauth related error'))
+    ) {
+      const hasServiceAccount = !!process.env.GOOGLE_APPLICATION_CREDENTIALS;
+      const remediation = hasServiceAccount
+        ? `Service account credentials may be expired or invalid. Verify:
+   1. GOOGLE_APPLICATION_CREDENTIALS points to a valid service account key file
+   2. The service account key has not been revoked or expired
+   3. The service account has required permissions (roles/storage.objectCreator, roles/storage.objectViewer)
+   4. Regenerate the service account key if needed:
+      gcloud iam service-accounts keys create key.json --iam-account=SERVICE_ACCOUNT@PROJECT.iam.gserviceaccount.com`
+        : `Application Default Credentials (ADC) have expired. Re-authenticate:
+   1. Run: gcloud auth application-default login
+   2. Set your project: gcloud config set project YOUR_PROJECT_ID
+   3. Verify: gcloud auth application-default print-access-token
+   
+   For production, use a service account key instead of ADC:
+   - Set GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account-key.json`;
+
+      return {
+        message: 'GCP authentication token expired (invalid_rapt)',
+        userMessage:
+          'GCP authentication failed: credentials expired. Please re-authenticate or update service account credentials.',
+        remediation,
+      };
+    }
+
+    // Check for other common auth errors
+    if (
+      errorCode === 401 ||
+      errorCode === 403 ||
+      errorMessage.includes('Could not load the default credentials') ||
+      errorMessage.includes('unauthorized') ||
+      errorMessage.includes('permission denied')
+    ) {
+      const remediation = `Verify GCP authentication:
+   1. Check GOOGLE_APPLICATION_CREDENTIALS env var (if using service account)
+   2. Or run: gcloud auth application-default login (for local dev)
+   3. Verify service account has required IAM roles
+   4. Check project ID matches your GCP project`;
+
+      return {
+        message: 'GCP authentication failed',
+        userMessage:
+          'GCP authentication failed: invalid or missing credentials.',
+        remediation,
+      };
+    }
+
+    return null;
   }
 
   /**


### PR DESCRIPTION
# Fix: GCP Storage Signed URL Generation Requires Service Account Credentials

## 🐛 Problem

The document download endpoint (`GET /v1/documents/:documentId/download`) was failing with:
```
Cannot sign data without `client_email`
```

**Root Cause:** GCP Cloud Storage signed URLs require a service account with `client_email`. The Storage client was using Application Default Credentials (ADC) from `gcloud auth application-default login`, which are user credentials and don't have `client_email`.

## ✅ Solution

1. **Explicit Credential Initialization**
   - Storage adapter now uses explicit service account credentials when `GOOGLE_APPLICATION_CREDENTIALS` is set
   - Falls back to ADC with warning if not set

2. **Startup Validation**
   - Validates credentials on startup
   - Checks for service account key file existence and `client_email` field
   - Logs clear warnings/errors immediately

3. **Secure Error Handling**
   - API responses no longer expose internal configuration details
   - Detailed remediation steps only in server logs (security best practice)
   - Returns generic `503 Service Unavailable` to clients

4. **Developer Experience**
   - Added automated setup script (`SETUP_SERVICE_ACCOUNT.sh`)
   - Updated README with setup instructions
   - Updated `.gitignore` to exclude service account keys

## 📝 Changes

- `src/document-processing/infrastructure/storage/gcp-storage.adapter.ts`
  - Initialize Storage with explicit credentials if `GOOGLE_APPLICATION_CREDENTIALS` is set
  - Add startup credential validation
  - Improve error detection and handling

- `.gitignore`
  - Exclude `.secrets/` directory and service account key patterns

- `README.md`
  - Add GCP credentials setup section with automated and manual options

- `SETUP_SERVICE_ACCOUNT.sh` (new)
  - Automated script to create service account, grant permissions, and generate key

## 🔒 Security

- ✅ Service account keys excluded from git via `.gitignore`
- ✅ No internal configuration details exposed in API responses
- ✅ Detailed remediation steps only in server logs

## 🧪 Testing

1. Set `GOOGLE_APPLICATION_CREDENTIALS` environment variable
2. Restart application
3. Check startup logs for credential validation
4. Test `GET /v1/documents/:documentId/download` endpoint

## 📚 Documentation

- Setup instructions added to README
- See `docs/gcp-authentication-setup.md` for complete guide
- See `VERIFY_GCP_CREDENTIALS.md` for troubleshooting

---

**Fixes:** Document download endpoint signed URL generation  
**Type:** Bug Fix  