### PR TITLE
feat(system-103): add RBAC-aware full-scope chat filtering

### DIFF
--- a/src/access-control/domain/services/access-grant.domain.service.ts
+++ b/src/access-control/domain/services/access-grant.domain.service.ts
@@ -290,4 +290,42 @@ export class AccessGrantDomainService {
   async getGrantById(grantId: number): Promise<NullableType<AccessGrant>> {
     return this.accessGrantRepository.findById(grantId);
   }
+
+  /**
+   * Get all document IDs accessible by a given actor.
+   *
+   * Combines:
+   * 1. Implicit access: documents where user is temporaryManager
+   * 2. Explicit access: active AccessGrants for the actor
+   *
+   * Used by SYSTEM-103 to enforce RBAC on full-scope chat requests.
+   *
+   * @param actorType - 'user' | 'manager'
+   * @param actorId - User/Manager ID
+   * @returns Array of unique document UUIDs
+   */
+  async getAccessibleDocumentIds(
+    actorType: ActorType,
+    actorId: number,
+  ): Promise<string[]> {
+    const docIds = new Set<string>();
+
+    // 1. Implicit access: docs where user is temporaryManager
+    if (actorType === 'user') {
+      const ownedDocs =
+        await this.documentRepository.findByTemporaryManagerId(actorId);
+      ownedDocs.forEach((doc) => docIds.add(doc.id));
+    }
+
+    // 2. Explicit access: active AccessGrants
+    if (actorType === 'user' || actorType === 'manager') {
+      const grants = await this.accessGrantRepository.findBySubject(
+        actorType as 'user' | 'manager',
+        actorId,
+      );
+      grants.forEach((grant) => docIds.add(grant.documentId));
+    }
+
+    return Array.from(docIds);
+  }
 }

--- a/src/anythingllm/chat/anythingllm-chat.service.spec.ts
+++ b/src/anythingllm/chat/anythingllm-chat.service.spec.ts
@@ -8,12 +8,18 @@ import { AnythingLLMOperation } from '../../anythingllm-policy/domain/anythingll
 describe('AnythingLLMChatService', () => {
   let service: AnythingLLMChatService;
   let orchestrator: { executeOperation: jest.Mock };
-  let accessGrantService: { hasAccess: jest.Mock };
+  let accessGrantService: {
+    hasAccess: jest.Mock;
+    getAccessibleDocumentIds: jest.Mock;
+  };
   let pathRepo: { findByDocumentIdsAndWorkspaceSlug: jest.Mock };
 
   beforeEach(async () => {
     orchestrator = { executeOperation: jest.fn() };
-    accessGrantService = { hasAccess: jest.fn() };
+    accessGrantService = {
+      hasAccess: jest.fn(),
+      getAccessibleDocumentIds: jest.fn(),
+    };
     pathRepo = { findByDocumentIdsAndWorkspaceSlug: jest.fn() };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -48,28 +54,69 @@ describe('AnythingLLMChatService', () => {
     provider: 'system',
   };
 
-  it('should use full-scope when documentIds is empty', async () => {
-    const mockStream = new ReadableStream({
+  function createMockSseStream(data: object) {
+    return new ReadableStream({
       start(controller) {
         controller.enqueue(
-          new TextEncoder().encode(
-            'data: {"id":"1","type":"textResponseChunk","textResponse":"hi","close":true}\n\n',
-          ),
+          new TextEncoder().encode(`data: ${JSON.stringify(data)}\n\n`),
         );
         controller.close();
       },
     });
+  }
 
+  function mockSuccessUpstream(data: object) {
     orchestrator.executeOperation.mockResolvedValue({
       ok: true,
       status: 200,
-      body: mockStream,
+      body: createMockSseStream(data),
       text: jest.fn(),
     } as any);
+  }
+
+  // ─── Full-scope tests (RBAC-aware) ───
+
+  it('should resolve RBAC-filtered docs and send allowedDocIds for full-scope', async () => {
+    const docId1 = '2e6e9b1b-6c2c-4b4c-9e2b-9f1d5f3d9b1a';
+    const docId2 = '3f7f0c2c-7d3d-5c5d-af3c-0g2e6g4e0c2b';
+    const anythingllmUuid1 = 'd14e9d15-b654-46b7-84dc-0414d1e7d131';
+    const anythingllmUuid2 = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
+
+    accessGrantService.getAccessibleDocumentIds.mockResolvedValue([
+      docId1,
+      docId2,
+    ]);
+    pathRepo.findByDocumentIdsAndWorkspaceSlug.mockResolvedValue([
+      {
+        documentId: docId1,
+        anythingllmDocPath: `custom-documents/doc1.pdf-${anythingllmUuid1}.json`,
+      },
+      {
+        documentId: docId2,
+        anythingllmDocPath: `custom-documents/doc2.pdf-${anythingllmUuid2}.json`,
+      },
+    ]);
+
+    mockSuccessUpstream({
+      id: '1',
+      type: 'textResponseChunk',
+      textResponse: 'hi',
+      close: true,
+    });
 
     const stream = await service.streamChatWithDocuments(
       { workspaceSlug: 'ws-1', message: 'hello', documentIds: [] },
       requesterContext as any,
+    );
+
+    expect(accessGrantService.getAccessibleDocumentIds).toHaveBeenCalledWith(
+      'user',
+      123,
+    );
+
+    expect(pathRepo.findByDocumentIdsAndWorkspaceSlug).toHaveBeenCalledWith(
+      [docId1, docId2],
+      'ws-1',
     );
 
     expect(orchestrator.executeOperation).toHaveBeenCalledWith(
@@ -78,6 +125,7 @@ describe('AnythingLLMChatService', () => {
         endpoint: expect.stringContaining('/v1/workspace/ws-1/stream-chat'),
         body: expect.objectContaining({
           documentPaths: ['*'],
+          allowedDocIds: [anythingllmUuid1, anythingllmUuid2],
           message: 'hello',
         }),
       }),
@@ -91,6 +139,71 @@ describe('AnythingLLMChatService', () => {
     reader.releaseLock();
   });
 
+  it('should send allowedDocIds for wildcard documentIds ["*"]', async () => {
+    const docId = '2e6e9b1b-6c2c-4b4c-9e2b-9f1d5f3d9b1a';
+    const anythingllmUuid = 'd14e9d15-b654-46b7-84dc-0414d1e7d131';
+
+    accessGrantService.getAccessibleDocumentIds.mockResolvedValue([docId]);
+    pathRepo.findByDocumentIdsAndWorkspaceSlug.mockResolvedValue([
+      {
+        documentId: docId,
+        anythingllmDocPath: `custom-documents/doc.pdf-${anythingllmUuid}.json`,
+      },
+    ]);
+
+    mockSuccessUpstream({
+      id: '1',
+      type: 'textResponseChunk',
+      textResponse: 'ok',
+      close: true,
+    });
+
+    await service.streamChatWithDocuments(
+      { workspaceSlug: 'ws-1', message: 'hello', documentIds: ['*'] },
+      requesterContext as any,
+    );
+
+    expect(orchestrator.executeOperation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.objectContaining({
+          documentPaths: ['*'],
+          allowedDocIds: [anythingllmUuid],
+        }),
+      }),
+    );
+  });
+
+  it('should throw 403 when user has no accessible documents (full-scope)', async () => {
+    accessGrantService.getAccessibleDocumentIds.mockResolvedValue([]);
+
+    await expect(
+      service.streamChatWithDocuments(
+        { workspaceSlug: 'ws-1', message: 'hello', documentIds: [] },
+        requesterContext as any,
+      ),
+    ).rejects.toThrow('User has no accessible documents');
+
+    expect(orchestrator.executeOperation).not.toHaveBeenCalled();
+  });
+
+  it('should throw 400 when accessible docs have no workspace mappings (full-scope)', async () => {
+    accessGrantService.getAccessibleDocumentIds.mockResolvedValue([
+      '2e6e9b1b-6c2c-4b4c-9e2b-9f1d5f3d9b1a',
+    ]);
+    pathRepo.findByDocumentIdsAndWorkspaceSlug.mockResolvedValue([]);
+
+    await expect(
+      service.streamChatWithDocuments(
+        { workspaceSlug: 'ws-1', message: 'hello', documentIds: [] },
+        requesterContext as any,
+      ),
+    ).rejects.toThrow('No accessible documents found in this workspace');
+
+    expect(orchestrator.executeOperation).not.toHaveBeenCalled();
+  });
+
+  // ─── Defined-scope tests (unchanged behavior) ───
+
   it('should validate access and resolve paths for defined scope', async () => {
     const docId = '2e6e9b1b-6c2c-4b4c-9e2b-9f1d5f3d9b1a';
     accessGrantService.hasAccess.mockResolvedValue(true);
@@ -98,23 +211,12 @@ describe('AnythingLLMChatService', () => {
       { documentId: docId, anythingllmDocPath: 'custom-documents/doc.json' },
     ]);
 
-    const mockStream = new ReadableStream({
-      start(controller) {
-        controller.enqueue(
-          new TextEncoder().encode(
-            'data: {"id":"1","type":"textResponseChunk","textResponse":"ok","close":true}\n\n',
-          ),
-        );
-        controller.close();
-      },
+    mockSuccessUpstream({
+      id: '1',
+      type: 'textResponseChunk',
+      textResponse: 'ok',
+      close: true,
     });
-
-    orchestrator.executeOperation.mockResolvedValue({
-      ok: true,
-      status: 200,
-      body: mockStream,
-      text: jest.fn(),
-    } as any);
 
     await service.streamChatWithDocuments(
       { workspaceSlug: 'ws-1', message: 'hello', documentIds: [docId] },
@@ -136,6 +238,7 @@ describe('AnythingLLMChatService', () => {
       expect.objectContaining({
         body: expect.objectContaining({
           documentPaths: ['custom-documents/doc.json'],
+          allowedDocIds: undefined,
         }),
       }),
     );

--- a/src/anythingllm/chat/anythingllm-chat.service.ts
+++ b/src/anythingllm/chat/anythingllm-chat.service.ts
@@ -13,6 +13,18 @@ import { DocumentAnythingLLMPathRepository } from '../provisioning/infrastructur
 import { ThreadStreamChatChunkSchema } from '../registry/schemas';
 import { DocumentScopedChatDto } from './dto/document-scoped-chat.dto';
 
+/**
+ * Extract AnythingLLM document UUID from a stored docpath.
+ * Docpath format: "custom-documents/filename-UUID.json"
+ * e.g. "custom-documents/cat.txt-d14e9d15-b654-46b7-84dc-0414d1e7d131.json"
+ */
+function extractAnythingLLMDocId(docPath: string): string | null {
+  const match = docPath.match(
+    /([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\.json$/i,
+  );
+  return match ? match[1] : null;
+}
+
 @Injectable()
 export class AnythingLLMChatService {
   private readonly logger = new Logger(AnythingLLMChatService.name);
@@ -44,8 +56,38 @@ export class AnythingLLMChatService {
       documentIds.includes('*');
 
     let documentPaths: string[];
+    let allowedDocUuids: string[] | undefined;
 
     if (isFullScope) {
+      // SYSTEM-103: RBAC-aware full scope
+      // Resolve all documents the user can access, then extract AnythingLLM UUIDs
+      // so AnythingLLM can filter vector search results at the Zilliz level.
+      const accessibleDocIds =
+        await this.accessGrantService.getAccessibleDocumentIds(
+          'user',
+          requesterUserId,
+        );
+
+      if (accessibleDocIds.length === 0) {
+        throw new ForbiddenException('User has no accessible documents');
+      }
+
+      const mappings =
+        await this.documentAnythingLLMPathRepository.findByDocumentIdsAndWorkspaceSlug(
+          accessibleDocIds,
+          workspaceSlug,
+        );
+
+      allowedDocUuids = mappings
+        .map((m) => extractAnythingLLMDocId(m.anythingllmDocPath))
+        .filter((id): id is string => id !== null);
+
+      if (allowedDocUuids.length === 0) {
+        throw new BadRequestException(
+          'No accessible documents found in this workspace',
+        );
+      }
+
       documentPaths = ['*'];
     } else {
       // Validate format early for clean errors (but allow upstream changes if needed)
@@ -106,6 +148,7 @@ export class AnythingLLMChatService {
       body: {
         message: dto.message,
         documentPaths,
+        allowedDocIds: allowedDocUuids,
         threadSlug: dto.threadSlug,
       },
     });


### PR DESCRIPTION
# SYSTEM-103: RBAC-Aware Full-Scope Chat via Vector Filtering (Keystone Side)

**Branch:** `experiment/document-scoped-chat` → `feature/document-scoped-chat`
**Ticket:** SYSTEM-103

## Summary

Full-scope chat (`documentIds: []` or `["*"]`) previously bypassed RBAC — AnythingLLM searched the entire workspace, including documents the user had lost access to (e.g., after assigning a manager). This PR adds server-side RBAC resolution so that Keystone resolves which documents the user can access, extracts their AnythingLLM UUIDs, and sends `allowedDocIds` in the request body. AnythingLLM then applies a Zilliz filter (`metadata["id"] in [...]`) to constrain vector search results.

> **Note:** The AnythingLLM-side changes (Zilliz filter, pinned doc filtering) are in a separate PR on the AnythingLLM project.

## Changes

### [access-grant.domain.service.ts](file:///Users/isaacpadilla/Combined/keystone-core-api/src/access-control/domain/services/access-grant.domain.service.ts) (+38)

Added [getAccessibleDocumentIds(actorType, actorId)](file:///Users/isaacpadilla/Combined/keystone-core-api/src/access-control/domain/services/access-grant.domain.service.ts#294-331) method:
- Queries `documentRepository.findByTemporaryManagerId()` for implicit access (user is temporary manager)
- Queries `accessGrantRepository.findBySubject()` for explicit grants
- Merges and deduplicates into a single list of Keystone document IDs

### [anythingllm-chat.service.ts](file:///Users/isaacpadilla/Combined/keystone-core-api/src/anythingllm/chat/anythingllm-chat.service.ts) (+43)

Updated the `isFullScope` branch in [streamChatWithDocuments](file:///Users/isaacpadilla/Combined/keystone-core-api/src/anythingllm/chat/anythingllm-chat.service.ts#38-171):
- Calls [getAccessibleDocumentIds](file:///Users/isaacpadilla/Combined/keystone-core-api/src/access-control/domain/services/access-grant.domain.service.ts#294-331) to resolve all docs the user can access
- Maps Keystone doc IDs → AnythingLLM docpaths via `findByDocumentIdsAndWorkspaceSlug`
- Extracts AnythingLLM document UUIDs from docpaths using [extractAnythingLLMDocId](file:///Users/isaacpadilla/Combined/keystone-core-api/src/anythingllm/chat/anythingllm-chat.service.ts#16-27) helper (regex on `custom-documents/filename-UUID.json`)
- Sends `allowedDocIds: string[]` in the upstream request body
- Throws `403` if user has no accessible documents
- Throws `400` if no accessible documents are mapped to the target workspace

Defined-scope chat is unchanged — `allowedDocIds` is `undefined` for specific doc requests.

### [anythingllm-chat.service.spec.ts](file:///Users/isaacpadilla/Combined/keystone-core-api/src/anythingllm/chat/anythingllm-chat.service.spec.ts) (+151, -24)

- Refactored mock setup into [mockSuccessUpstream](file:///Users/isaacpadilla/Combined/keystone-core-api/src/anythingllm/chat/anythingllm-chat.service.spec.ts#68-76) helper
- Added 4 new tests:
  - Full-scope resolves RBAC and sends `allowedDocIds`
  - Wildcard `["*"]` sends `allowedDocIds`
  - No accessible documents → `ForbiddenException` (403)
  - No workspace mappings → `BadRequestException` (400)
- Updated existing defined-scope tests to verify `allowedDocIds: undefined`

## How It Works

```
User sends: POST /api/v1/chat/stream { documentIds: [], workspaceSlug: "ws-232" }
                                    │
                    ┌───────────────▼───────────────────┐
                    │   getAccessibleDocumentIds()       │
                    │   → temporaryManager docs          │
                    │   → explicit AccessGrant docs      │
                    │   → deduplicate                    │
                    └───────────────┬───────────────────┘
                                    │ [docId1, docId2]
                    ┌───────────────▼───────────────────┐
                    │   findByDocumentIdsAndWorkspaceSlug │
                    │   → Keystone IDs to docpaths       │
                    └───────────────┬───────────────────┘
                                    │
                    ┌───────────────▼───────────────────┐
                    │   extractAnythingLLMDocId()        │
                    │   docpath → UUID extraction        │
                    └───────────────┬───────────────────┘
                                    │ [uuid1, uuid2]
                    ┌───────────────▼───────────────────┐
                    │   AnythingLLM stream-chat          │
                    │   body: { allowedDocIds: [...] }   │
                    │   → Zilliz: metadata["id"] in [...] │
                    └───────────────────────────────────┘
```

## Testing

### Unit Tests
```
Test Suites: 15 passed, 15 total
Tests:       123 passed, 123 total
```

### Manual Integration Tests ✅
| Scenario | Result |
|----------|--------|
| User uploads doc → full-scope chat works | ✅ |
| User assigns manager → full-scope chat filters doc out | ✅ |
| Manager grants access back → full-scope chat works again | ✅ |
| Defined-scope with valid doc | ✅ |
| Defined-scope with invalid/revoked doc → 403 | ✅ |
| Full-scope with no docs → 403 | ✅ |
| Full-scope with docs not in workspace → 400 | ✅ |
| Multi-doc scoping (doc1 accessible, doc2 not) | ✅ |
| Cross-user workspace isolation | ✅ |
